### PR TITLE
Phase 2: mocked repository browser shell

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,9 +1,19 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.auth import router as auth_router
+from app.routes.repos import router as repos_router
 
 app = FastAPI(title="Splash-UI API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(auth_router)
+app.include_router(repos_router)
 
 
 @app.get("/health")

--- a/apps/api/app/routes/repos.py
+++ b/apps/api/app/routes/repos.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Query
+
+from app.services.github_client import get_file_content, get_repo_tree, list_repos
+
+router = APIRouter(tags=["repositories"])
+
+
+@router.get("/repos")
+def repos() -> list[dict[str, object]]:
+    return list_repos()
+
+
+@router.get("/tree")
+def tree(repo: str = Query(..., min_length=1)) -> list[dict[str, object]]:
+    return get_repo_tree(repo)
+
+
+@router.get("/file")
+def file_content(
+    repo: str = Query(..., min_length=1),
+    path: str = Query(..., min_length=1),
+) -> dict[str, str]:
+    return get_file_content(repo, path)

--- a/apps/api/app/services/github_client.py
+++ b/apps/api/app/services/github_client.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class Repository(TypedDict):
+    id: str
+    name: str
+    owner: str
+    full_name: str
+    default_branch: str
+    visibility: str
+    description: str
+
+
+class TreeNode(TypedDict):
+    id: str
+    name: str
+    path: str
+    type: str
+    children: list["TreeNode"]
+
+
+class FileContent(TypedDict):
+    repository: str
+    path: str
+    encoding: str
+    language: str
+    content: str
+
+
+MOCK_REPOSITORIES: list[Repository] = [
+    {
+        "id": "repo-splash-ui",
+        "name": "splash-ui",
+        "owner": "KasturiKugathas",
+        "full_name": "KasturiKugathas/splash-ui",
+        "default_branch": "main",
+        "visibility": "private",
+        "description": "Governed configuration editing for GitHub repositories.",
+    },
+    {
+        "id": "repo-platform-config",
+        "name": "platform-config",
+        "owner": "KasturiKugathas",
+        "full_name": "KasturiKugathas/platform-config",
+        "default_branch": "main",
+        "visibility": "private",
+        "description": "Application and infrastructure settings managed through pull requests.",
+    },
+    {
+        "id": "repo-observability-config",
+        "name": "observability-config",
+        "owner": "KasturiKugathas",
+        "full_name": "KasturiKugathas/observability-config",
+        "default_branch": "main",
+        "visibility": "public",
+        "description": "Monitoring rules, alerting routes, and shared dashboard metadata.",
+    },
+]
+
+MOCK_TREE_BY_REPOSITORY: dict[str, list[TreeNode]] = {
+    "KasturiKugathas/splash-ui": [
+        {
+            "id": "apps",
+            "name": "apps",
+            "path": "apps",
+            "type": "dir",
+            "children": [
+                {
+                    "id": "apps-web",
+                    "name": "web",
+                    "path": "apps/web",
+                    "type": "dir",
+                    "children": [
+                        {
+                            "id": "apps-web-env",
+                            "name": "app.config.json",
+                            "path": "apps/web/app.config.json",
+                            "type": "file",
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        },
+        {
+            "id": "infra",
+            "name": "infra",
+            "path": "infra",
+            "type": "dir",
+            "children": [
+                {
+                    "id": "infra-monitoring",
+                    "name": "monitoring.yaml",
+                    "path": "infra/monitoring.yaml",
+                    "type": "file",
+                    "children": [],
+                },
+                {
+                    "id": "infra-policies",
+                    "name": "policies.xml",
+                    "path": "infra/policies.xml",
+                    "type": "file",
+                    "children": [],
+                },
+            ],
+        },
+    ],
+    "KasturiKugathas/platform-config": [
+        {
+            "id": "clusters",
+            "name": "clusters",
+            "path": "clusters",
+            "type": "dir",
+            "children": [
+                {
+                    "id": "clusters-prod",
+                    "name": "prod",
+                    "path": "clusters/prod",
+                    "type": "dir",
+                    "children": [
+                        {
+                            "id": "clusters-prod-values",
+                            "name": "values.yaml",
+                            "path": "clusters/prod/values.yaml",
+                            "type": "file",
+                            "children": [],
+                        },
+                        {
+                            "id": "clusters-prod-feature-flags",
+                            "name": "feature-flags.json",
+                            "path": "clusters/prod/feature-flags.json",
+                            "type": "file",
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+    "KasturiKugathas/observability-config": [
+        {
+            "id": "grafana",
+            "name": "grafana",
+            "path": "grafana",
+            "type": "dir",
+            "children": [
+                {
+                    "id": "grafana-dashboards",
+                    "name": "dashboards",
+                    "path": "grafana/dashboards",
+                    "type": "dir",
+                    "children": [
+                        {
+                            "id": "grafana-main-dashboard",
+                            "name": "home-dashboard.json",
+                            "path": "grafana/dashboards/home-dashboard.json",
+                            "type": "file",
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+MOCK_FILE_CONTENT: dict[tuple[str, str], FileContent] = {
+    (
+        "KasturiKugathas/splash-ui",
+        "apps/web/app.config.json",
+    ): {
+        "repository": "KasturiKugathas/splash-ui",
+        "path": "apps/web/app.config.json",
+        "encoding": "utf-8",
+        "language": "json",
+        "content": '{\n  "name": "Splash-UI",\n  "featureFlags": {\n    "repoBrowser": true,\n    "diffPreview": false\n  }\n}',
+    },
+    (
+        "KasturiKugathas/splash-ui",
+        "infra/monitoring.yaml",
+    ): {
+        "repository": "KasturiKugathas/splash-ui",
+        "path": "infra/monitoring.yaml",
+        "encoding": "utf-8",
+        "language": "yaml",
+        "content": "alerts:\n  enabled: true\n  destination: pagerduty\n",
+    },
+    (
+        "KasturiKugathas/splash-ui",
+        "infra/policies.xml",
+    ): {
+        "repository": "KasturiKugathas/splash-ui",
+        "path": "infra/policies.xml",
+        "encoding": "utf-8",
+        "language": "xml",
+        "content": "<policies>\n  <policy name=\"require-review\" enabled=\"true\" />\n</policies>\n",
+    },
+    (
+        "KasturiKugathas/platform-config",
+        "clusters/prod/values.yaml",
+    ): {
+        "repository": "KasturiKugathas/platform-config",
+        "path": "clusters/prod/values.yaml",
+        "encoding": "utf-8",
+        "language": "yaml",
+        "content": "replicaCount: 3\nimage:\n  tag: stable\n",
+    },
+    (
+        "KasturiKugathas/platform-config",
+        "clusters/prod/feature-flags.json",
+    ): {
+        "repository": "KasturiKugathas/platform-config",
+        "path": "clusters/prod/feature-flags.json",
+        "encoding": "utf-8",
+        "language": "json",
+        "content": '{\n  "newSidebar": true,\n  "approvalGate": "required"\n}',
+    },
+    (
+        "KasturiKugathas/observability-config",
+        "grafana/dashboards/home-dashboard.json",
+    ): {
+        "repository": "KasturiKugathas/observability-config",
+        "path": "grafana/dashboards/home-dashboard.json",
+        "encoding": "utf-8",
+        "language": "json",
+        "content": '{\n  "title": "Platform Home",\n  "refresh": "30s"\n}',
+    },
+}
+
+
+def list_repos() -> list[Repository]:
+    return MOCK_REPOSITORIES
+
+
+def get_repo_tree(repo_full_name: str) -> list[TreeNode]:
+    return MOCK_TREE_BY_REPOSITORY.get(repo_full_name, [])
+
+
+def get_file_content(repo_full_name: str, path: str) -> FileContent:
+    content = MOCK_FILE_CONTENT.get((repo_full_name, path))
+    if content:
+        return content
+
+    return {
+        "repository": repo_full_name,
+        "path": path,
+        "encoding": "utf-8",
+        "language": "text",
+        "content": "Mock file content unavailable for the requested path.",
+    }

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -1,8 +1,70 @@
+import Link from "next/link";
+
 export default function ProtectedAppPage() {
   return (
-    <main style={{ padding: 24, fontFamily: "sans-serif" }}>
-      <h1>Protected Area</h1>
-      <p>If middleware is working, unauthenticated users are redirected to /login.</p>
+    <main
+      style={{
+        minHeight: "100vh",
+        padding: "40px 24px",
+        display: "grid",
+        placeItems: "center",
+      }}
+    >
+      <section
+        style={{
+          maxWidth: 760,
+          width: "100%",
+          borderRadius: 28,
+          border: "1px solid var(--line)",
+          background: "var(--panel)",
+          boxShadow: "var(--shadow)",
+          padding: 32,
+          display: "grid",
+          gap: 18,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            color: "var(--accent)",
+            fontSize: 13,
+            textTransform: "uppercase",
+            letterSpacing: "0.12em",
+          }}
+        >
+          Protected area
+        </p>
+        <h1 style={{ margin: 0, fontSize: "clamp(2.2rem, 4vw, 3.5rem)" }}>Splash-UI workspace</h1>
+        <p style={{ margin: 0, color: "var(--muted)", lineHeight: 1.7 }}>
+          Phase 2 adds the first repository browser shell. Continue into the mocked GitHub
+          workspace to inspect repositories, browse supported config files, and preview content.
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <Link
+            href="/repositories"
+            style={{
+              textDecoration: "none",
+              borderRadius: 999,
+              padding: "12px 18px",
+              background: "var(--accent)",
+              color: "#f7f4ec",
+            }}
+          >
+            Open repositories
+          </Link>
+          <Link
+            href="/login"
+            style={{
+              textDecoration: "none",
+              borderRadius: 999,
+              padding: "12px 18px",
+              border: "1px solid var(--line)",
+            }}
+          >
+            Return to login
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/app/repositories/page.tsx
+++ b/apps/web/app/app/repositories/page.tsx
@@ -1,0 +1,5 @@
+import RepoBrowser from "../../../src/components/repo-browser";
+
+export default function RepositoriesPage() {
+  return <RepoBrowser />;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,49 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f1e8;
+  --panel: rgba(255, 252, 246, 0.92);
+  --panel-strong: #fffaf0;
+  --ink: #1f1a14;
+  --muted: #6e6255;
+  --line: rgba(76, 61, 44, 0.16);
+  --accent: #0f766e;
+  --accent-soft: rgba(15, 118, 110, 0.14);
+  --warn: #b42318;
+  --warn-soft: rgba(180, 35, 24, 0.12);
+  --shadow: 0 24px 60px rgba(72, 52, 37, 0.14);
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top, rgba(15, 118, 110, 0.12), transparent 34%),
+    linear-gradient(180deg, #f7f4ec 0%, #ede4d5 100%);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background: transparent;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea,
+pre,
+code {
+  font: inherit;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 import Providers from "./providers";
+import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Splash-UI",

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,26 +1,78 @@
 export default function LoginPage() {
   return (
-    <main style={{ maxWidth: 420, margin: "40px auto", fontFamily: "sans-serif" }}>
-      <h1>Sign in to Splash-UI</h1>
-      <form>
-        <label htmlFor="email">Email</label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          placeholder="you@company.com"
-          style={{ display: "block", width: "100%", margin: "8px 0 16px", padding: 8 }}
-        />
-        <button type="submit" style={{ width: "100%", padding: 10 }}>
-          Send email login link
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+      }}
+    >
+      <section
+        style={{
+          maxWidth: 460,
+          width: "100%",
+          borderRadius: 28,
+          border: "1px solid var(--line)",
+          background: "var(--panel)",
+          boxShadow: "var(--shadow)",
+          padding: 28,
+        }}
+      >
+        <h1 style={{ marginTop: 0, marginBottom: 8 }}>Sign in to Splash-UI</h1>
+        <p style={{ marginTop: 0, color: "var(--muted)", lineHeight: 1.6 }}>
+          Use email magic-link auth or GitHub OAuth to open the repository browser.
+        </p>
+
+        <form>
+          <label htmlFor="email" style={{ display: "grid", gap: 8, fontSize: 14 }}>
+            Work email
+            <input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="you@company.com"
+              style={{
+                display: "block",
+                width: "100%",
+                marginBottom: 16,
+                padding: 12,
+                borderRadius: 14,
+                border: "1px solid var(--line)",
+                background: "var(--panel-strong)",
+              }}
+            />
+          </label>
+          <button
+            type="submit"
+            style={{
+              width: "100%",
+              padding: 12,
+              borderRadius: 999,
+              border: 0,
+              background: "var(--accent)",
+              color: "#f7f4ec",
+            }}
+          >
+            Send email login link
+          </button>
+        </form>
+
+        <div style={{ margin: "16px 0", textAlign: "center", color: "var(--muted)" }}>or</div>
+
+        <button
+          type="button"
+          style={{
+            width: "100%",
+            padding: 12,
+            borderRadius: 999,
+            border: "1px solid var(--line)",
+            background: "transparent",
+          }}
+        >
+          Continue with GitHub
         </button>
-      </form>
-
-      <div style={{ margin: "16px 0", textAlign: "center" }}>or</div>
-
-      <button type="button" style={{ width: "100%", padding: 10 }}>
-        Continue with GitHub
-      </button>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,10 +2,70 @@ import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <main style={{ padding: 24, fontFamily: "sans-serif" }}>
-      <h1>Splash-UI</h1>
-      <p>Phase 1 scaffold is ready.</p>
-      <Link href="/login">Go to Login</Link>
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+      }}
+    >
+      <section
+        style={{
+          maxWidth: 900,
+          borderRadius: 32,
+          border: "1px solid var(--line)",
+          background: "var(--panel)",
+          boxShadow: "var(--shadow)",
+          padding: "40px clamp(24px, 4vw, 48px)",
+          display: "grid",
+          gap: 22,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            color: "var(--accent)",
+            fontSize: 13,
+            textTransform: "uppercase",
+            letterSpacing: "0.14em",
+          }}
+        >
+          Splash-UI
+        </p>
+        <h1 style={{ margin: 0, fontSize: "clamp(2.8rem, 6vw, 5.5rem)", lineHeight: 0.95 }}>
+          Govern config changes through a safer GitHub workflow.
+        </h1>
+        <p style={{ margin: 0, color: "var(--muted)", maxWidth: 720, lineHeight: 1.7 }}>
+          The local scaffold now includes mocked auth and a repository browser shell for JSON, YAML,
+          and XML configuration files.
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <Link
+            href="/login"
+            style={{
+              textDecoration: "none",
+              borderRadius: 999,
+              padding: "12px 18px",
+              background: "var(--accent)",
+              color: "#f7f4ec",
+            }}
+          >
+            Go to login
+          </Link>
+          <Link
+            href="/repositories"
+            style={{
+              textDecoration: "none",
+              borderRadius: 999,
+              padding: "12px 18px",
+              border: "1px solid var(--line)",
+            }}
+          >
+            View repository shell
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/repositories/page.tsx
+++ b/apps/web/app/repositories/page.tsx
@@ -1,0 +1,5 @@
+import RepoBrowser from "../../src/components/repo-browser";
+
+export default function PublicRepositoriesPage() {
+  return <RepoBrowser />;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 
-// NOTE: This file should not be edited.
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,0 +1,991 @@
+{
+  "name": "splash-ui-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "splash-ui-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "15.3.5",
+        "react": "19.1.0",
+        "react-dom": "19.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.16.5",
+        "@types/react": "19.1.8",
+        "@types/react-dom": "19.1.6",
+        "typescript": "5.8.3"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
+      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
+      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
+      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
+      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
+      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
+      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
+      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
+      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
+      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
+      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001778",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
+      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.3.5",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.3.5",
+        "@next/swc-darwin-x64": "15.3.5",
+        "@next/swc-linux-arm64-gnu": "15.3.5",
+        "@next/swc-linux-arm64-musl": "15.3.5",
+        "@next/swc-linux-x64-gnu": "15.3.5",
+        "@next/swc-linux-x64-musl": "15.3.5",
+        "@next/swc-win32-arm64-msvc": "15.3.5",
+        "@next/swc-win32-x64-msvc": "15.3.5",
+        "sharp": "^0.34.1"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/web/src/components/repo-browser.tsx
+++ b/apps/web/src/components/repo-browser.tsx
@@ -1,0 +1,730 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Repository = {
+  id: string;
+  name: string;
+  owner: string;
+  full_name: string;
+  default_branch: string;
+  visibility: string;
+  description: string;
+};
+
+type TreeNode = {
+  id: string;
+  name: string;
+  path: string;
+  type: "dir" | "file";
+  children: TreeNode[];
+};
+
+type FileContent = {
+  repository: string;
+  path: string;
+  encoding: string;
+  language: string;
+  content: string;
+};
+
+type ToastState = {
+  title: string;
+  detail: string;
+};
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000";
+const extensionOptions = [
+  { value: "all", label: "All supported files" },
+  { value: ".json", label: "JSON only" },
+  { value: ".yaml", label: "YAML only" },
+  { value: ".yml", label: "YML only" },
+  { value: ".xml", label: "XML only" },
+];
+
+function matchesExtension(path: string, filter: string) {
+  if (filter === "all") {
+    return [".json", ".yaml", ".yml", ".xml"].some((extension) => path.endsWith(extension));
+  }
+
+  return path.endsWith(filter);
+}
+
+function filterTree(nodes: TreeNode[], filter: string): TreeNode[] {
+  return nodes
+    .map((node) => {
+      if (node.type === "file") {
+        return matchesExtension(node.path, filter) ? node : null;
+      }
+
+      const filteredChildren = filterTree(node.children, filter);
+      if (filteredChildren.length === 0) {
+        return null;
+      }
+
+      return { ...node, children: filteredChildren };
+    })
+    .filter((node): node is TreeNode => node !== null);
+}
+
+function flattenFiles(nodes: TreeNode[]): number {
+  return nodes.reduce((count, node) => {
+    if (node.type === "file") {
+      return count + 1;
+    }
+
+    return count + flattenFiles(node.children);
+  }, 0);
+}
+
+function ErrorToast({ toast, onDismiss }: { toast: ToastState; onDismiss: () => void }) {
+  return (
+    <div style={toastStyles.shell} role="alert">
+      <div>
+        <strong style={{ display: "block", marginBottom: 4 }}>{toast.title}</strong>
+        <span style={{ color: "var(--muted)" }}>{toast.detail}</span>
+      </div>
+      <button onClick={onDismiss} style={toastStyles.dismiss} type="button">
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function TreeBranch({
+  nodes,
+  onSelect,
+  selectedPath,
+}: {
+  nodes: TreeNode[];
+  onSelect: (path: string) => void;
+  selectedPath: string | null;
+}) {
+  return (
+    <ul style={treeStyles.list}>
+      {nodes.map((node) => (
+        <TreeNodeItem
+          key={node.id}
+          node={node}
+          onSelect={onSelect}
+          selectedPath={selectedPath}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function TreeNodeItem({
+  node,
+  onSelect,
+  selectedPath,
+}: {
+  node: TreeNode;
+  onSelect: (path: string) => void;
+  selectedPath: string | null;
+}) {
+  const [open, setOpen] = useState(true);
+
+  if (node.type === "dir") {
+    return (
+      <li>
+        <button onClick={() => setOpen((current) => !current)} style={treeStyles.folderButton} type="button">
+          <span>{open ? "▾" : "▸"}</span>
+          <span>{node.name}</span>
+        </button>
+        {open ? (
+          <div style={{ marginLeft: 16 }}>
+            <TreeBranch nodes={node.children} onSelect={onSelect} selectedPath={selectedPath} />
+          </div>
+        ) : null}
+      </li>
+    );
+  }
+
+  const selected = selectedPath === node.path;
+
+  return (
+    <li>
+      <button
+        onClick={() => onSelect(node.path)}
+        style={{
+          ...treeStyles.fileButton,
+          ...(selected ? treeStyles.fileButtonActive : null),
+        }}
+        type="button"
+      >
+        <span style={{ minWidth: 28, color: "var(--muted)" }}>file</span>
+        <span>{node.name}</span>
+      </button>
+    </li>
+  );
+}
+
+async function requestJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export default function RepoBrowser() {
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [selectedRepository, setSelectedRepository] = useState<Repository | null>(null);
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<FileContent | null>(null);
+  const [repoSearch, setRepoSearch] = useState("");
+  const [extensionFilter, setExtensionFilter] = useState("all");
+  const [loadingRepos, setLoadingRepos] = useState(true);
+  const [loadingTree, setLoadingTree] = useState(false);
+  const [loadingFile, setLoadingFile] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadRepositories() {
+      setLoadingRepos(true);
+
+      try {
+        const repoList = await requestJson<Repository[]>("/repos");
+        if (!active) {
+          return;
+        }
+
+        setRepositories(repoList);
+        setSelectedRepository(repoList[0] ?? null);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+
+        setToast({
+          title: "Could not load repositories",
+          detail: error instanceof Error ? error.message : "Unexpected API error.",
+        });
+      } finally {
+        if (active) {
+          setLoadingRepos(false);
+        }
+      }
+    }
+
+    void loadRepositories();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadTree() {
+      if (!selectedRepository) {
+        setTree([]);
+        setSelectedPath(null);
+        setFileContent(null);
+        return;
+      }
+
+      setLoadingTree(true);
+      setSelectedPath(null);
+      setFileContent(null);
+
+      try {
+        const response = await requestJson<TreeNode[]>(
+          `/tree?repo=${encodeURIComponent(selectedRepository.full_name)}`
+        );
+        if (!active) {
+          return;
+        }
+
+        setTree(response);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+
+        setToast({
+          title: "Could not load repository tree",
+          detail: error instanceof Error ? error.message : "Unexpected API error.",
+        });
+      } finally {
+        if (active) {
+          setLoadingTree(false);
+        }
+      }
+    }
+
+    void loadTree();
+
+    return () => {
+      active = false;
+    };
+  }, [selectedRepository]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadFile() {
+      if (!selectedRepository || !selectedPath) {
+        setFileContent(null);
+        return;
+      }
+
+      setLoadingFile(true);
+
+      try {
+        const response = await requestJson<FileContent>(
+          `/file?repo=${encodeURIComponent(selectedRepository.full_name)}&path=${encodeURIComponent(
+            selectedPath
+          )}`
+        );
+        if (!active) {
+          return;
+        }
+
+        setFileContent(response);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+
+        setToast({
+          title: "Could not load file content",
+          detail: error instanceof Error ? error.message : "Unexpected API error.",
+        });
+      } finally {
+        if (active) {
+          setLoadingFile(false);
+        }
+      }
+    }
+
+    void loadFile();
+
+    return () => {
+      active = false;
+    };
+  }, [selectedRepository, selectedPath]);
+
+  const visibleRepositories = useMemo(() => {
+    const value = repoSearch.trim().toLowerCase();
+    if (!value) {
+      return repositories;
+    }
+
+    return repositories.filter((repository) => {
+      return (
+        repository.full_name.toLowerCase().includes(value) ||
+        repository.description.toLowerCase().includes(value)
+      );
+    });
+  }, [repoSearch, repositories]);
+
+  const visibleTree = useMemo(() => filterTree(tree, extensionFilter), [tree, extensionFilter]);
+  const visibleFileCount = useMemo(() => flattenFiles(visibleTree), [visibleTree]);
+
+  return (
+    <main style={pageStyles.shell}>
+      <section style={pageStyles.hero}>
+        <div>
+          <p style={pageStyles.eyebrow}>Phase 2</p>
+          <h1 style={pageStyles.title}>Repository browser shell</h1>
+          <p style={pageStyles.subtitle}>
+            Browse mocked GitHub repositories, filter supported config files, and preview file
+            contents before the editor phase lands.
+          </p>
+        </div>
+        <div style={pageStyles.heroCard}>
+          <span>Supported file types</span>
+          <strong>JSON, YAML, YML, XML</strong>
+        </div>
+      </section>
+
+      {toast ? <ErrorToast toast={toast} onDismiss={() => setToast(null)} /> : null}
+
+      <section style={pageStyles.grid}>
+        <aside style={panelStyles.root}>
+          <div style={panelStyles.header}>
+            <div>
+              <p style={panelStyles.kicker}>Repositories</p>
+              <h2 style={panelStyles.title}>Connected repos</h2>
+            </div>
+            <span style={panelStyles.badge}>
+              {loadingRepos ? "Loading" : `${visibleRepositories.length} shown`}
+            </span>
+          </div>
+
+          <label style={panelStyles.label}>
+            Search repositories
+            <input
+              onChange={(event) => setRepoSearch(event.target.value)}
+              placeholder="Filter by name or description"
+              style={panelStyles.input}
+              type="search"
+              value={repoSearch}
+            />
+          </label>
+
+          {loadingRepos ? (
+            <div style={panelStyles.emptyState}>
+              <strong>Loading repository list</strong>
+              <span>Fetching mocked GitHub repositories from the API.</span>
+            </div>
+          ) : visibleRepositories.length === 0 ? (
+            <div style={panelStyles.emptyState}>
+              <strong>No repositories match</strong>
+              <span>Adjust the search input to see mocked repos again.</span>
+            </div>
+          ) : (
+            <div style={panelStyles.stack}>
+              {visibleRepositories.map((repository) => {
+                const selected = repository.full_name === selectedRepository?.full_name;
+
+                return (
+                  <button
+                    key={repository.id}
+                    onClick={() => setSelectedRepository(repository)}
+                    style={{
+                      ...panelStyles.repoButton,
+                      ...(selected ? panelStyles.repoButtonActive : null),
+                    }}
+                    type="button"
+                  >
+                    <div style={{ display: "grid", gap: 6, textAlign: "left" }}>
+                      <strong>{repository.full_name}</strong>
+                      <span style={{ color: "var(--muted)" }}>{repository.description}</span>
+                    </div>
+                    <span style={panelStyles.metaPill}>
+                      {repository.visibility} · {repository.default_branch}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </aside>
+
+        <section style={panelStyles.root}>
+          <div style={panelStyles.header}>
+            <div>
+              <p style={panelStyles.kicker}>Repository tree</p>
+              <h2 style={panelStyles.title}>Config files</h2>
+            </div>
+            <span style={panelStyles.badge}>{visibleFileCount} files</span>
+          </div>
+
+          <div style={panelStyles.toolbar}>
+            <label style={panelStyles.labelCompact}>
+              Extension filter
+              <select
+                onChange={(event) => setExtensionFilter(event.target.value)}
+                style={panelStyles.select}
+                value={extensionFilter}
+              >
+                {extensionOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          {loadingTree ? (
+            <div style={panelStyles.emptyState}>
+              <strong>Loading tree</strong>
+              <span>Building the repository file tree for the selected repo.</span>
+            </div>
+          ) : visibleTree.length === 0 ? (
+            <div style={panelStyles.emptyState}>
+              <strong>No supported files found</strong>
+              <span>Select another filter or repository to see files.</span>
+            </div>
+          ) : (
+            <TreeBranch
+              nodes={visibleTree}
+              onSelect={(path) => setSelectedPath(path)}
+              selectedPath={selectedPath}
+            />
+          )}
+        </section>
+
+        <section style={panelStyles.root}>
+          <div style={panelStyles.header}>
+            <div>
+              <p style={panelStyles.kicker}>File viewer</p>
+              <h2 style={panelStyles.title}>Preview</h2>
+            </div>
+            <span style={panelStyles.badge}>
+              {fileContent ? fileContent.language.toUpperCase() : "No file"}
+            </span>
+          </div>
+
+          {loadingFile ? (
+            <div style={panelStyles.emptyState}>
+              <strong>Loading file content</strong>
+              <span>Fetching the selected file from the mocked API.</span>
+            </div>
+          ) : fileContent ? (
+            <div style={panelStyles.viewer}>
+              <div style={panelStyles.viewerHeader}>
+                <strong>{fileContent.path}</strong>
+                <span style={{ color: "var(--muted)" }}>{fileContent.repository}</span>
+              </div>
+              <pre style={panelStyles.pre}>{fileContent.content}</pre>
+            </div>
+          ) : (
+            <div style={panelStyles.emptyState}>
+              <strong>Select a config file</strong>
+              <span>Choose a JSON, YAML, YML, or XML file from the tree to preview it here.</span>
+            </div>
+          )}
+        </section>
+      </section>
+    </main>
+  );
+}
+
+const pageStyles = {
+  shell: {
+    padding: "32px clamp(20px, 3vw, 44px) 48px",
+    display: "grid",
+    gap: 24,
+  },
+  hero: {
+    display: "grid",
+    gap: 20,
+    alignItems: "end",
+    gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+  },
+  eyebrow: {
+    margin: 0,
+    color: "var(--accent)",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase" as const,
+    fontSize: 12,
+  },
+  title: {
+    margin: "10px 0 12px",
+    fontSize: "clamp(2.4rem, 4vw, 4rem)",
+    lineHeight: 1,
+  },
+  subtitle: {
+    margin: 0,
+    color: "var(--muted)",
+    maxWidth: 720,
+    fontSize: "1.04rem",
+    lineHeight: 1.6,
+  },
+  heroCard: {
+    padding: 20,
+    borderRadius: "var(--radius-lg)",
+    background: "rgba(255, 248, 235, 0.8)",
+    border: "1px solid var(--line)",
+    boxShadow: "var(--shadow)",
+    display: "grid",
+    gap: 8,
+    minHeight: 120,
+    alignContent: "center",
+  },
+  grid: {
+    display: "grid",
+    gap: 18,
+    gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+  },
+};
+
+const panelStyles = {
+  root: {
+    borderRadius: "var(--radius-xl)",
+    border: "1px solid var(--line)",
+    background: "var(--panel)",
+    boxShadow: "var(--shadow)",
+    padding: 20,
+    display: "grid",
+    gap: 16,
+    alignContent: "start",
+  },
+  header: {
+    display: "flex",
+    alignItems: "start",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  kicker: {
+    margin: 0,
+    color: "var(--muted)",
+    fontSize: 13,
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.08em",
+  },
+  title: {
+    margin: "6px 0 0",
+    fontSize: 24,
+  },
+  badge: {
+    borderRadius: 999,
+    padding: "8px 12px",
+    background: "var(--accent-soft)",
+    color: "var(--accent)",
+    fontSize: 13,
+    whiteSpace: "nowrap" as const,
+  },
+  label: {
+    display: "grid",
+    gap: 8,
+    fontSize: 14,
+  },
+  labelCompact: {
+    display: "grid",
+    gap: 8,
+    fontSize: 13,
+    color: "var(--muted)",
+  },
+  input: {
+    width: "100%",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--line)",
+    padding: "12px 14px",
+    background: "var(--panel-strong)",
+  },
+  select: {
+    width: "100%",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--line)",
+    padding: "10px 12px",
+    background: "var(--panel-strong)",
+  },
+  toolbar: {
+    display: "flex",
+    gap: 12,
+    alignItems: "center",
+  },
+  stack: {
+    display: "grid",
+    gap: 12,
+  },
+  repoButton: {
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid var(--line)",
+    background: "rgba(255,255,255,0.64)",
+    padding: 16,
+    display: "grid",
+    gap: 12,
+    cursor: "pointer",
+  },
+  repoButtonActive: {
+    border: "1px solid rgba(15, 118, 110, 0.35)",
+    background: "rgba(15, 118, 110, 0.08)",
+  },
+  metaPill: {
+    justifySelf: "start",
+    borderRadius: 999,
+    padding: "6px 10px",
+    background: "rgba(31, 26, 20, 0.06)",
+    color: "var(--muted)",
+    fontSize: 12,
+  },
+  emptyState: {
+    borderRadius: "var(--radius-lg)",
+    border: "1px dashed var(--line)",
+    background: "rgba(255,255,255,0.54)",
+    minHeight: 180,
+    padding: 20,
+    display: "grid",
+    gap: 6,
+    alignContent: "center",
+    color: "var(--muted)",
+  },
+  viewer: {
+    display: "grid",
+    gap: 12,
+  },
+  viewerHeader: {
+    display: "grid",
+    gap: 4,
+  },
+  pre: {
+    margin: 0,
+    padding: 18,
+    borderRadius: "var(--radius-lg)",
+    background: "#1f1a14",
+    color: "#f8efe0",
+    overflowX: "auto" as const,
+    fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+    fontSize: 13,
+    lineHeight: 1.6,
+  },
+};
+
+const treeStyles = {
+  list: {
+    listStyle: "none",
+    padding: 0,
+    margin: 0,
+    display: "grid",
+    gap: 8,
+  },
+  folderButton: {
+    width: "100%",
+    border: 0,
+    background: "transparent",
+    padding: "8px 0",
+    cursor: "pointer",
+    display: "flex",
+    gap: 10,
+    alignItems: "center",
+    fontWeight: 600,
+    textAlign: "left" as const,
+  },
+  fileButton: {
+    width: "100%",
+    border: "1px solid transparent",
+    borderRadius: "var(--radius-md)",
+    background: "rgba(255,255,255,0.65)",
+    padding: "10px 12px",
+    cursor: "pointer",
+    display: "flex",
+    gap: 10,
+    alignItems: "center",
+    textAlign: "left" as const,
+  },
+  fileButtonActive: {
+    border: "1px solid rgba(15, 118, 110, 0.35)",
+    background: "rgba(15, 118, 110, 0.1)",
+  },
+};
+
+const toastStyles = {
+  shell: {
+    position: "sticky" as const,
+    top: 16,
+    zIndex: 10,
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 16,
+    alignItems: "start",
+    padding: 16,
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid rgba(180, 35, 24, 0.24)",
+    background: "var(--warn-soft)",
+    boxShadow: "var(--shadow)",
+  },
+  dismiss: {
+    border: 0,
+    borderRadius: 999,
+    padding: "8px 12px",
+    background: "#fff",
+    cursor: "pointer",
+  },
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,19 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docs/auth-flow.md
+++ b/docs/auth-flow.md
@@ -1,5 +1,7 @@
 # Authentication Flow (Phase 1)
 
+See [GitHub OAuth Scopes](./github-scopes.md) for the minimum repository access Splash-UI needs during the repository browser phase.
+
 ```mermaid
 sequenceDiagram
   autonumber

--- a/docs/github-scopes.md
+++ b/docs/github-scopes.md
@@ -1,0 +1,16 @@
+# GitHub OAuth Scopes (Phase 2)
+
+Splash-UI only needs the minimum scopes required to read repositories and open pull requests on behalf of the signed-in user.
+
+## Required Scopes
+
+| Scope | Why Splash-UI needs it |
+| --- | --- |
+| `read:user` | Resolve the signed-in GitHub identity and associate it with a Splash-UI account. |
+| `repo` | Read private repository metadata and contents, create branches, commit changes, and open pull requests. |
+
+## Scope Notes
+
+- Use `repo` only when private repositories must be supported.
+- If Splash-UI is later limited to public repositories, replace `repo` with narrower public-read scopes.
+- Avoid requesting admin, delete, webhook, or organization scopes until those workflows are implemented.


### PR DESCRIPTION
## Summary
- add mocked GitHub repository client functions and `/repos`, `/tree`, `/file` FastAPI endpoints
- document the minimum GitHub OAuth scopes for repository browsing
- add the Phase 2 repository browser shell with repo search, extension filtering, loading states, file preview, and reusable API error toasts

## Verification
- `python3 -m compileall app`
- `PYTHONPATH=/Users/kasturikugathas/Documents/Playground/phase2-work/splash-ui/apps/api /Users/kasturikugathas/Documents/workspace/splash-ui/apps/api/.venv/bin/python -c "from app.main import app; print(app.title)"`
- `npx tsc --noEmit`
- `npm run build`

Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41
Closes #42
Closes #43
Closes #44
Closes #45