### PR TITLE
Phase 2.1: config tree parser and editor

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.auth import router as auth_router
+from app.routes.config import router as config_router
 from app.routes.repos import router as repos_router
 
 app = FastAPI(title="Splash-UI API")
@@ -13,6 +14,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.include_router(auth_router)
+app.include_router(config_router)
 app.include_router(repos_router)
 
 

--- a/apps/api/app/routes/config.py
+++ b/apps/api/app/routes/config.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, HTTPException, Query
+
+from app.services.config_parser import build_config_tree
+from app.services.github_client import GitHubClientError, get_file_content
+
+router = APIRouter(tags=["config"])
+
+
+@router.get("/config-tree")
+def config_tree(
+    repo: str = Query(..., min_length=1),
+    path: str = Query(..., min_length=1),
+) -> dict[str, object]:
+    try:
+        file_content = get_file_content(repo, path)
+        return {
+            "repository": repo,
+            "path": path,
+            "tree": build_config_tree(file_content),
+        }
+    except GitHubClientError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc

--- a/apps/api/app/services/config_parser.py
+++ b/apps/api/app/services/config_parser.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from io import StringIO
+from pathlib import PurePosixPath
+from typing import Any, Literal, TypedDict
+
+import yaml
+
+from app.services.github_client import FileContent, GitHubClientError
+
+ConfigNodeKind = Literal["string", "number", "boolean", "object", "array", "null"]
+
+
+class ConfigNode(TypedDict):
+    key: str
+    path: str
+    kind: ConfigNodeKind
+    value: str | float | bool | None
+    children: list["ConfigNode"]
+
+
+def parse_config(file_content: FileContent) -> Any:
+    suffix = PurePosixPath(file_content["path"]).suffix.lower()
+    raw_content = file_content["content"]
+
+    try:
+        if suffix == ".json":
+            return json.loads(raw_content)
+        if suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(raw_content)
+        if suffix == ".xml":
+            element = ET.parse(StringIO(raw_content)).getroot()
+            return {element.tag: _xml_to_object(element)}
+    except (json.JSONDecodeError, yaml.YAMLError, ET.ParseError) as exc:
+        raise GitHubClientError(
+            f"Could not parse {file_content['path']}: {exc}",
+            status_code=422,
+        ) from exc
+
+    raise GitHubClientError(
+        f"Unsupported config format for {file_content['path']}.",
+        status_code=400,
+    )
+
+
+def build_config_tree(file_content: FileContent) -> ConfigNode:
+    parsed = parse_config(file_content)
+    return normalize_config(key=PurePosixPath(file_content["path"]).name, value=parsed, path="$")
+
+
+def normalize_config(key: str, value: Any, path: str) -> ConfigNode:
+    if isinstance(value, dict):
+        children = [
+            normalize_config(
+                key=str(child_key),
+                value=child_value,
+                path=f"{path}.{child_key}" if path != "$" else f"$.{child_key}",
+            )
+            for child_key, child_value in value.items()
+        ]
+        return {
+            "key": key,
+            "path": path,
+            "kind": "object",
+            "value": None,
+            "children": children,
+        }
+
+    if isinstance(value, list):
+        children = [
+            normalize_config(
+                key=f"[{index}]",
+                value=child_value,
+                path=f"{path}[{index}]",
+            )
+            for index, child_value in enumerate(value)
+        ]
+        return {
+            "key": key,
+            "path": path,
+            "kind": "array",
+            "value": None,
+            "children": children,
+        }
+
+    if isinstance(value, bool):
+        return {"key": key, "path": path, "kind": "boolean", "value": value, "children": []}
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return {"key": key, "path": path, "kind": "number", "value": float(value), "children": []}
+
+    if value is None:
+        return {"key": key, "path": path, "kind": "null", "value": None, "children": []}
+
+    return {"key": key, "path": path, "kind": "string", "value": str(value), "children": []}
+
+
+def _xml_to_object(element: ET.Element) -> Any:
+    attributes = {f"@{key}": value for key, value in element.attrib.items()}
+    child_elements = list(element)
+
+    if not child_elements:
+        text = (element.text or "").strip()
+        if attributes and text:
+            return {**attributes, "#text": text}
+        if attributes:
+            return attributes
+        return text
+
+    grouped_children: dict[str, list[Any]] = {}
+    for child in child_elements:
+        grouped_children.setdefault(child.tag, []).append(_xml_to_object(child))
+
+    normalized_children: dict[str, Any] = {}
+    for child_tag, values in grouped_children.items():
+        normalized_children[child_tag] = values[0] if len(values) == 1 else values
+
+    text = (element.text or "").strip()
+    if text:
+        normalized_children["#text"] = text
+
+    return {**attributes, **normalized_children}

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.116.1
+PyYAML==6.0.2
 uvicorn==0.35.0

--- a/apps/web/app/app/editor/page.tsx
+++ b/apps/web/app/app/editor/page.tsx
@@ -1,0 +1,11 @@
+import ConfigEditor from "../../../src/components/config-editor/config-editor";
+
+export default async function ProtectedEditorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ repo?: string; path?: string }>;
+}) {
+  const params = await searchParams;
+
+  return <ConfigEditor repository={params.repo ?? ""} path={params.path ?? ""} />;
+}

--- a/apps/web/app/editor/page.tsx
+++ b/apps/web/app/editor/page.tsx
@@ -1,0 +1,11 @@
+import ConfigEditor from "../../src/components/config-editor/config-editor";
+
+export default async function EditorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ repo?: string; path?: string }>;
+}) {
+  const params = await searchParams;
+
+  return <ConfigEditor repository={params.repo ?? ""} path={params.path ?? ""} />;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "splash-ui-web",
       "version": "0.1.0",
       "dependencies": {
-        "next": "15.3.5",
+        "next": "^15.5.12",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -496,15 +496,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
-      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
+      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
-      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
+      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
       "cpu": [
         "arm64"
       ],
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
-      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
+      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
       "cpu": [
         "x64"
       ],
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
-      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
+      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
       "cpu": [
         "arm64"
       ],
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
-      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
+      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
       "cpu": [
         "arm64"
       ],
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
-      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
+      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
       "cpu": [
         "x64"
       ],
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
-      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
+      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
       "cpu": [
         "x64"
       ],
@@ -598,9 +598,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
-      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
+      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
       "cpu": [
         "arm64"
       ],
@@ -614,9 +614,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
-      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
+      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
       "cpu": [
         "x64"
       ],
@@ -628,12 +628,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -672,17 +666,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -747,16 +730,13 @@
       }
     },
     "node_modules/next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
-      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
-      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "version": "15.5.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
+      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.5",
-        "@swc/counter": "0.1.3",
+        "@next/env": "15.5.12",
         "@swc/helpers": "0.5.15",
-        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -768,19 +748,19 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.5",
-        "@next/swc-darwin-x64": "15.3.5",
-        "@next/swc-linux-arm64-gnu": "15.3.5",
-        "@next/swc-linux-arm64-musl": "15.3.5",
-        "@next/swc-linux-x64-gnu": "15.3.5",
-        "@next/swc-linux-x64-musl": "15.3.5",
-        "@next/swc-win32-arm64-msvc": "15.3.5",
-        "@next/swc-win32-x64-msvc": "15.3.5",
-        "sharp": "^0.34.1"
+        "@next/swc-darwin-arm64": "15.5.12",
+        "@next/swc-darwin-x64": "15.5.12",
+        "@next/swc-linux-arm64-gnu": "15.5.12",
+        "@next/swc-linux-arm64-musl": "15.5.12",
+        "@next/swc-linux-x64-gnu": "15.5.12",
+        "@next/swc-linux-x64-musl": "15.5.12",
+        "@next/swc-win32-arm64-msvc": "15.5.12",
+        "@next/swc-win32-x64-msvc": "15.5.12",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.51.1",
         "babel-plugin-react-compiler": "*",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -927,14 +907,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/styled-jsx": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,14 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.3.5",
+    "next": "^15.5.12",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "5.8.3",
     "@types/node": "22.16.5",
     "@types/react": "19.1.8",
-    "@types/react-dom": "19.1.6"
+    "@types/react-dom": "19.1.6",
+    "typescript": "5.8.3"
   }
 }

--- a/apps/web/src/components/config-editor/config-editor.tsx
+++ b/apps/web/src/components/config-editor/config-editor.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import ConfigTreeRenderer from "./config-tree-renderer";
+import { getConfigTree, type ConfigNode, type ConfigTreeResponse } from "../../lib/config-tree";
+
+type ToastState = {
+  title: string;
+  detail: string;
+};
+
+function ErrorBanner({ toast }: { toast: ToastState }) {
+  return (
+    <div style={bannerStyles.root} role="alert">
+      <strong>{toast.title}</strong>
+      <span>{toast.detail}</span>
+    </div>
+  );
+}
+
+export default function ConfigEditor({
+  repository,
+  path,
+}: {
+  repository: string;
+  path: string;
+}) {
+  const [response, setResponse] = useState<ConfigTreeResponse | null>(null);
+  const [draftTree, setDraftTree] = useState<ConfigNode | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadTree() {
+      if (!repository || !path) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setToast(null);
+
+      try {
+        const nextResponse = await getConfigTree(repository, path);
+        if (!active) {
+          return;
+        }
+        console.log("config-tree", nextResponse);
+        setResponse(nextResponse);
+        setDraftTree(nextResponse.tree);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setToast({
+          title: "Could not load config tree",
+          detail: error instanceof Error ? error.message : "Unexpected API error.",
+        });
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadTree();
+
+    return () => {
+      active = false;
+    };
+  }, [path, repository]);
+
+  if (!repository || !path) {
+    return (
+      <main style={pageStyles.shell}>
+        <section style={pageStyles.card}>
+          <p style={pageStyles.eyebrow}>Phase 2.1</p>
+          <h1 style={pageStyles.title}>Config editor</h1>
+          <div style={pageStyles.emptyState}>
+            <strong>No file selected</strong>
+            <span>Open the repository browser first and choose a supported config file.</span>
+            <Link href="/repositories" style={pageStyles.linkButton}>
+              Back to repositories
+            </Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main style={pageStyles.shell}>
+      <section style={pageStyles.card}>
+        <div style={pageStyles.header}>
+          <div style={{ display: "grid", gap: 10 }}>
+            <p style={pageStyles.eyebrow}>Phase 2.1</p>
+            <h1 style={pageStyles.title}>Config editor</h1>
+            <p style={pageStyles.subtitle}>
+              Review the normalized config tree, then adjust scalar values in place. Persistence is
+              not wired yet; this phase focuses on parsing and rendering.
+            </p>
+          </div>
+          <Link href={`/repositories`} style={pageStyles.secondaryLink}>
+            Back to repositories
+          </Link>
+        </div>
+
+        <div style={pageStyles.metaGrid}>
+          <div style={pageStyles.metaCard}>
+            <strong>Repository</strong>
+            <span>{repository}</span>
+          </div>
+          <div style={pageStyles.metaCard}>
+            <strong>File</strong>
+            <span>{path}</span>
+          </div>
+        </div>
+
+        {toast ? <ErrorBanner toast={toast} /> : null}
+
+        {loading ? (
+          <div style={pageStyles.emptyState}>
+            <strong>Loading config structure</strong>
+            <span>Fetching and normalizing the selected file.</span>
+          </div>
+        ) : draftTree && draftTree.children.length > 0 ? (
+          <ConfigTreeRenderer node={draftTree} onNodeChange={setDraftTree} />
+        ) : (
+          <div style={pageStyles.emptyState}>
+            <strong>No editable fields found</strong>
+            <span>The selected file parsed successfully but did not produce any editable nodes.</span>
+          </div>
+        )}
+
+        {response ? (
+          <section style={pageStyles.debugPanel}>
+            <div style={pageStyles.debugHeader}>
+              <strong>Normalized structure</strong>
+              <span>Current editor state for this file.</span>
+            </div>
+            <pre style={pageStyles.pre}>{JSON.stringify(draftTree ?? response.tree, null, 2)}</pre>
+          </section>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+const pageStyles = {
+  shell: {
+    padding: "32px clamp(20px, 3vw, 44px) 48px",
+  },
+  card: {
+    display: "grid",
+    gap: 20,
+    borderRadius: "var(--radius-xl)",
+    border: "1px solid var(--line)",
+    background: "var(--panel)",
+    boxShadow: "var(--shadow)",
+    padding: "28px clamp(18px, 2vw, 32px)",
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 16,
+    alignItems: "start",
+    flexWrap: "wrap" as const,
+  },
+  eyebrow: {
+    margin: 0,
+    color: "var(--accent)",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase" as const,
+    fontSize: 12,
+  },
+  title: {
+    margin: 0,
+    fontSize: "clamp(2rem, 4vw, 3.6rem)",
+    lineHeight: 1,
+  },
+  subtitle: {
+    margin: 0,
+    maxWidth: 760,
+    color: "var(--muted)",
+    lineHeight: 1.6,
+  },
+  secondaryLink: {
+    textDecoration: "none",
+    borderRadius: 999,
+    border: "1px solid var(--line)",
+    padding: "12px 18px",
+    alignSelf: "start",
+  },
+  linkButton: {
+    textDecoration: "none",
+    borderRadius: 999,
+    background: "var(--accent)",
+    color: "#f7f4ec",
+    padding: "12px 18px",
+    justifySelf: "start",
+  },
+  metaGrid: {
+    display: "grid",
+    gap: 14,
+    gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+  },
+  metaCard: {
+    display: "grid",
+    gap: 6,
+    padding: 16,
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid var(--line)",
+    background: "rgba(255,255,255,0.7)",
+    color: "var(--muted)",
+    wordBreak: "break-word" as const,
+  },
+  emptyState: {
+    display: "grid",
+    gap: 8,
+    padding: 24,
+    borderRadius: "var(--radius-lg)",
+    border: "1px dashed var(--line)",
+    background: "rgba(255,255,255,0.6)",
+    color: "var(--muted)",
+  },
+  debugPanel: {
+    display: "grid",
+    gap: 10,
+  },
+  debugHeader: {
+    display: "grid",
+    gap: 4,
+    color: "var(--muted)",
+  },
+  pre: {
+    margin: 0,
+    padding: 18,
+    borderRadius: "var(--radius-lg)",
+    background: "#1f1a14",
+    color: "#f8efe0",
+    overflowX: "auto" as const,
+    fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+    fontSize: 13,
+    lineHeight: 1.6,
+  },
+};
+
+const bannerStyles = {
+  root: {
+    display: "grid",
+    gap: 6,
+    padding: 16,
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid rgba(180, 35, 24, 0.24)",
+    background: "var(--warn-soft)",
+    color: "#7a271a",
+  },
+};

--- a/apps/web/src/components/config-editor/config-section.tsx
+++ b/apps/web/src/components/config-editor/config-section.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+export default function ConfigSection({
+  title,
+  description,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  description?: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <section style={styles.root}>
+      <button onClick={() => setIsOpen((value) => !value)} style={styles.header} type="button">
+        <div style={{ display: "grid", gap: 4, textAlign: "left" }}>
+          <strong>{title}</strong>
+          {description ? <span style={styles.description}>{description}</span> : null}
+        </div>
+        <span style={styles.chevron}>{isOpen ? "−" : "+"}</span>
+      </button>
+      {isOpen ? <div style={styles.content}>{children}</div> : null}
+    </section>
+  );
+}
+
+const styles = {
+  root: {
+    border: "1px solid var(--line)",
+    borderRadius: "var(--radius-lg)",
+    background: "rgba(255, 255, 255, 0.7)",
+    overflow: "hidden",
+  },
+  header: {
+    width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16,
+    padding: "14px 16px",
+    border: 0,
+    background: "rgba(15, 118, 110, 0.08)",
+    cursor: "pointer",
+  },
+  content: {
+    padding: 16,
+    display: "grid",
+    gap: 14,
+  },
+  description: {
+    color: "var(--muted)",
+    fontSize: 13,
+  },
+  chevron: {
+    fontSize: 28,
+    lineHeight: 1,
+    color: "var(--accent)",
+  },
+};

--- a/apps/web/src/components/config-editor/config-tree-renderer.tsx
+++ b/apps/web/src/components/config-editor/config-tree-renderer.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import ConfigSection from "./config-section";
+import KeyValueRow from "./key-value-row";
+import type { ConfigNode } from "../../lib/config-tree";
+
+function inputStyle() {
+  return {
+    width: "100%",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--line)",
+    padding: "10px 12px",
+    background: "var(--panel-strong)",
+  };
+}
+
+function updateNode(nodes: ConfigNode[], targetPath: string, nextValue: ConfigNode["value"]): ConfigNode[] {
+  return nodes.map((node) => {
+    if (node.path === targetPath) {
+      return { ...node, value: nextValue };
+    }
+
+    if (node.children.length === 0) {
+      return node;
+    }
+
+    return { ...node, children: updateNode(node.children, targetPath, nextValue) };
+  });
+}
+
+function renderScalarNode(node: ConfigNode, onChange: (path: string, value: ConfigNode["value"]) => void) {
+  if (node.kind === "string" || node.kind === "null") {
+    return (
+      <KeyValueRow key={node.path} label={node.key} hint={node.path}>
+        <input
+          onChange={(event) => onChange(node.path, event.target.value)}
+          style={inputStyle()}
+          type="text"
+          value={typeof node.value === "string" ? node.value : ""}
+        />
+      </KeyValueRow>
+    );
+  }
+
+  if (node.kind === "number") {
+    return (
+      <KeyValueRow key={node.path} label={node.key} hint={node.path}>
+        <input
+          onChange={(event) => onChange(node.path, event.target.value === "" ? null : Number(event.target.value))}
+          style={inputStyle()}
+          type="number"
+          value={typeof node.value === "number" ? node.value : ""}
+        />
+      </KeyValueRow>
+    );
+  }
+
+  if (node.kind === "boolean") {
+    return (
+      <KeyValueRow key={node.path} label={node.key} hint={node.path}>
+        <label style={toggleStyles.shell}>
+          <input
+            checked={Boolean(node.value)}
+            onChange={(event) => onChange(node.path, event.target.checked)}
+            type="checkbox"
+          />
+          <span>{node.value ? "Enabled" : "Disabled"}</span>
+        </label>
+      </KeyValueRow>
+    );
+  }
+
+  return null;
+}
+
+function renderNode(node: ConfigNode, onChange: (path: string, value: ConfigNode["value"]) => void) {
+  if (node.kind === "object") {
+    return (
+      <ConfigSection
+        key={node.path}
+        title={node.key}
+        description={`${node.children.length} nested field${node.children.length === 1 ? "" : "s"}`}
+      >
+        {node.children.map((child) => renderNode(child, onChange))}
+      </ConfigSection>
+    );
+  }
+
+  if (node.kind === "array") {
+    return (
+      <ConfigSection
+        key={node.path}
+        title={node.key}
+        description={`${node.children.length} item${node.children.length === 1 ? "" : "s"}`}
+      >
+        {node.children.length === 0 ? (
+          <div style={emptyStyles}>No array items available.</div>
+        ) : (
+          node.children.map((child) => renderNode(child, onChange))
+        )}
+      </ConfigSection>
+    );
+  }
+
+  return renderScalarNode(node, onChange);
+}
+
+export default function ConfigTreeRenderer({
+  node,
+  onNodeChange,
+}: {
+  node: ConfigNode;
+  onNodeChange: (nextTree: ConfigNode) => void;
+}) {
+  const handleChange = (targetPath: string, nextValue: ConfigNode["value"]) => {
+    onNodeChange({
+      ...node,
+      children: updateNode(node.children, targetPath, nextValue),
+    });
+  };
+
+  return <div style={styles.root}>{node.children.map((child) => renderNode(child, handleChange))}</div>;
+}
+
+const styles = {
+  root: {
+    display: "grid",
+    gap: 14,
+  },
+};
+
+const toggleStyles = {
+  shell: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 10,
+    padding: "10px 12px",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--line)",
+    background: "var(--panel-strong)",
+  },
+};
+
+const emptyStyles = {
+  padding: "10px 12px",
+  color: "var(--muted)",
+  border: "1px dashed var(--line)",
+  borderRadius: "var(--radius-md)",
+};

--- a/apps/web/src/components/config-editor/key-value-row.tsx
+++ b/apps/web/src/components/config-editor/key-value-row.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export default function KeyValueRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: ReactNode;
+}) {
+  return (
+    <label style={styles.root}>
+      <div style={styles.labelColumn}>
+        <strong>{label}</strong>
+        <span style={styles.hint}>{hint}</span>
+      </div>
+      <div>{children}</div>
+    </label>
+  );
+}
+
+const styles = {
+  root: {
+    display: "grid",
+    gridTemplateColumns: "minmax(160px, 0.8fr) minmax(0, 1.2fr)",
+    gap: 16,
+    alignItems: "center",
+    padding: "14px 16px",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--line)",
+    background: "rgba(255,255,255,0.72)",
+  },
+  labelColumn: {
+    display: "grid",
+    gap: 4,
+  },
+  hint: {
+    color: "var(--muted)",
+    fontSize: 12,
+    wordBreak: "break-all" as const,
+  },
+};

--- a/apps/web/src/components/repo-browser.tsx
+++ b/apps/web/src/components/repo-browser.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+
+import { getConfigTree } from "../lib/config-tree";
 
 type Repository = {
   id: string;
@@ -26,6 +30,11 @@ type FileContent = {
   encoding: string;
   language: string;
   content: string;
+};
+
+type ConfigStructureState = {
+  status: "idle" | "loading" | "ready" | "error";
+  detail?: string;
 };
 
 type ToastState = {
@@ -186,11 +195,13 @@ async function requestJson<T>(path: string): Promise<T> {
 }
 
 export default function RepoBrowser() {
+  const router = useRouter();
   const [repositories, setRepositories] = useState<Repository[]>([]);
   const [selectedRepository, setSelectedRepository] = useState<Repository | null>(null);
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<FileContent | null>(null);
+  const [configStructure, setConfigStructure] = useState<ConfigStructureState>({ status: "idle" });
   const [repoSearch, setRepoSearch] = useState("");
   const [extensionFilter, setExtensionFilter] = useState("all");
   const [loadingRepos, setLoadingRepos] = useState(true);
@@ -288,6 +299,7 @@ export default function RepoBrowser() {
     async function loadFile() {
       if (!selectedRepository || !selectedPath) {
         setFileContent(null);
+        setConfigStructure({ status: "idle" });
         return;
       }
 
@@ -326,6 +338,45 @@ export default function RepoBrowser() {
       active = false;
     };
   }, [selectedRepository, selectedPath]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadStructure() {
+      if (!selectedRepository || !selectedPath) {
+        setConfigStructure({ status: "idle" });
+        return;
+      }
+
+      setConfigStructure({ status: "loading" });
+
+      try {
+        const response = await getConfigTree(selectedRepository.full_name, selectedPath);
+        if (!active) {
+          return;
+        }
+        console.log("config-tree", response);
+        setConfigStructure({
+          status: "ready",
+          detail: `${response.tree.children.length} top-level field${response.tree.children.length === 1 ? "" : "s"}`,
+        });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setConfigStructure({
+          status: "error",
+          detail: error instanceof Error ? error.message : "Unexpected API error.",
+        });
+      }
+    }
+
+    void loadStructure();
+
+    return () => {
+      active = false;
+    };
+  }, [selectedPath, selectedRepository]);
 
   const visibleRepositories = useMemo(() => {
     const value = repoSearch.trim().toLowerCase();
@@ -492,7 +543,47 @@ export default function RepoBrowser() {
                 <strong>{fileContent.path}</strong>
                 <span style={{ color: "var(--muted)" }}>{fileContent.repository}</span>
               </div>
+              <div style={panelStyles.callout}>
+                <strong>Config structure</strong>
+                <span style={{ color: "var(--muted)" }}>
+                  {configStructure.status === "loading"
+                    ? "Fetching normalized structure for the editor."
+                    : configStructure.status === "ready"
+                      ? configStructure.detail
+                      : configStructure.status === "error"
+                        ? configStructure.detail
+                        : "Select a file to begin parsing."}
+                </span>
+              </div>
               <pre style={panelStyles.pre}>{fileContent.content}</pre>
+              <div style={panelStyles.actions}>
+                <button
+                  onClick={() => {
+                    if (!selectedRepository || !selectedPath) {
+                      return;
+                    }
+                    router.push(
+                      `/editor?repo=${encodeURIComponent(selectedRepository.full_name)}&path=${encodeURIComponent(
+                        selectedPath
+                      )}`
+                    );
+                  }}
+                  style={panelStyles.primaryAction}
+                  type="button"
+                >
+                  Open in config editor
+                </button>
+                {selectedRepository && selectedPath ? (
+                  <Link
+                    href={`/editor?repo=${encodeURIComponent(selectedRepository.full_name)}&path=${encodeURIComponent(
+                      selectedPath
+                    )}`}
+                    style={panelStyles.secondaryAction}
+                  >
+                    Open dedicated route
+                  </Link>
+                ) : null}
+              </div>
             </div>
           ) : (
             <div style={panelStyles.emptyState}>
@@ -661,9 +752,36 @@ const panelStyles = {
     display: "grid",
     gap: 12,
   },
+  callout: {
+    display: "grid",
+    gap: 4,
+    padding: 14,
+    borderRadius: "var(--radius-md)",
+    background: "rgba(15, 118, 110, 0.08)",
+    border: "1px solid rgba(15, 118, 110, 0.18)",
+  },
   viewerHeader: {
     display: "grid",
     gap: 4,
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap" as const,
+    gap: 10,
+  },
+  primaryAction: {
+    border: 0,
+    borderRadius: 999,
+    padding: "12px 18px",
+    background: "var(--accent)",
+    color: "#f7f4ec",
+    cursor: "pointer",
+  },
+  secondaryAction: {
+    textDecoration: "none",
+    borderRadius: 999,
+    padding: "12px 18px",
+    border: "1px solid var(--line)",
   },
   pre: {
     margin: 0,

--- a/apps/web/src/lib/config-tree.ts
+++ b/apps/web/src/lib/config-tree.ts
@@ -1,0 +1,46 @@
+export type ConfigNodeKind = "string" | "number" | "boolean" | "object" | "array" | "null";
+
+export type ConfigNode = {
+  key: string;
+  path: string;
+  kind: ConfigNodeKind;
+  value: string | number | boolean | null;
+  children: ConfigNode[];
+};
+
+export type ConfigTreeResponse = {
+  repository: string;
+  path: string;
+  tree: ConfigNode;
+};
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000";
+
+async function requestJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    let detail = `API request failed with status ${response.status}`;
+
+    try {
+      const payload = (await response.json()) as { detail?: string };
+      if (payload.detail) {
+        detail = payload.detail;
+      }
+    } catch {
+      // Keep the default message when the backend does not return JSON.
+    }
+
+    throw new Error(detail);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function getConfigTree(repo: string, path: string) {
+  return requestJson<ConfigTreeResponse>(
+    `/config-tree?repo=${encodeURIComponent(repo)}&path=${encodeURIComponent(path)}`
+  );
+}


### PR DESCRIPTION
## Summary
- add backend config parsing and normalization for JSON, YAML, and XML files
- expose a `/config-tree` API endpoint for normalized config editor data
- add the Phase 2.1 editor route, renderer components, and repository-browser handoff into the editor flow

## Verification
- `python3 -m compileall app`
- `PYTHONPATH=/Users/kasturikugathas/Documents/Playground/phase2-work/splash-ui/apps/api .venv/bin/python - <<'PY' ... PY` sample parser checks for JSON/YAML/XML
- `PYTHONPATH=/Users/kasturikugathas/Documents/Playground/phase2-work/splash-ui/apps/api .venv/bin/python - <<'PY' from app.main import app; print(app.title) PY`
- `npx tsc --noEmit`
- `npm run build`