### PR TITLE
Phase 3: editor state and parser adapters

### DIFF
--- a/apps/api/app/services/config_parser.py
+++ b/apps/api/app/services/config_parser.py
@@ -1,48 +1,24 @@
 from __future__ import annotations
 
-import json
-import xml.etree.ElementTree as ET
-from io import StringIO
 from pathlib import PurePosixPath
-from typing import Any, Literal, TypedDict
+from typing import Any
 
-import yaml
-
+from app.services.config_types import ConfigNode
 from app.services.github_client import FileContent, GitHubClientError
-
-ConfigNodeKind = Literal["string", "number", "boolean", "object", "array", "null"]
-
-
-class ConfigNode(TypedDict):
-    key: str
-    path: str
-    kind: ConfigNodeKind
-    value: str | float | bool | None
-    children: list["ConfigNode"]
+from app.services.parsers.resolver import resolve_parser
 
 
 def parse_config(file_content: FileContent) -> Any:
-    suffix = PurePosixPath(file_content["path"]).suffix.lower()
     raw_content = file_content["content"]
+    parser = resolve_parser(file_content["path"])
 
     try:
-        if suffix == ".json":
-            return json.loads(raw_content)
-        if suffix in {".yaml", ".yml"}:
-            return yaml.safe_load(raw_content)
-        if suffix == ".xml":
-            element = ET.parse(StringIO(raw_content)).getroot()
-            return {element.tag: _xml_to_object(element)}
-    except (json.JSONDecodeError, yaml.YAMLError, ET.ParseError) as exc:
+        return parser.parse(raw_content)
+    except Exception as exc:
         raise GitHubClientError(
             f"Could not parse {file_content['path']}: {exc}",
             status_code=422,
         ) from exc
-
-    raise GitHubClientError(
-        f"Unsupported config format for {file_content['path']}.",
-        status_code=400,
-    )
 
 
 def build_config_tree(file_content: FileContent) -> ConfigNode:
@@ -95,30 +71,3 @@ def normalize_config(key: str, value: Any, path: str) -> ConfigNode:
         return {"key": key, "path": path, "kind": "null", "value": None, "children": []}
 
     return {"key": key, "path": path, "kind": "string", "value": str(value), "children": []}
-
-
-def _xml_to_object(element: ET.Element) -> Any:
-    attributes = {f"@{key}": value for key, value in element.attrib.items()}
-    child_elements = list(element)
-
-    if not child_elements:
-        text = (element.text or "").strip()
-        if attributes and text:
-            return {**attributes, "#text": text}
-        if attributes:
-            return attributes
-        return text
-
-    grouped_children: dict[str, list[Any]] = {}
-    for child in child_elements:
-        grouped_children.setdefault(child.tag, []).append(_xml_to_object(child))
-
-    normalized_children: dict[str, Any] = {}
-    for child_tag, values in grouped_children.items():
-        normalized_children[child_tag] = values[0] if len(values) == 1 else values
-
-    text = (element.text or "").strip()
-    if text:
-        normalized_children["#text"] = text
-
-    return {**attributes, **normalized_children}

--- a/apps/api/app/services/config_types.py
+++ b/apps/api/app/services/config_types.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+ConfigNodeKind = Literal["string", "number", "boolean", "object", "array", "null"]
+
+
+class ConfigNode(TypedDict):
+    key: str
+    path: str
+    kind: ConfigNodeKind
+    value: str | float | bool | None
+    children: list["ConfigNode"]

--- a/apps/api/app/services/parsers/base.py
+++ b/apps/api/app/services/parsers/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class ParserAdapter(Protocol):
+    name: str
+    supported_extensions: tuple[str, ...]
+
+    def parse(self, content: str) -> Any: ...
+
+    def serialize(self, value: Any) -> str: ...

--- a/apps/api/app/services/parsers/json_adapter.py
+++ b/apps/api/app/services/parsers/json_adapter.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class JsonParserAdapter:
+    name = "json"
+    supported_extensions = (".json",)
+
+    def parse(self, content: str) -> Any:
+        return json.loads(content)
+
+    def serialize(self, value: Any) -> str:
+        return json.dumps(value, indent=2, ensure_ascii=True)

--- a/apps/api/app/services/parsers/resolver.py
+++ b/apps/api/app/services/parsers/resolver.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from app.services.github_client import GitHubClientError
+from app.services.parsers.base import ParserAdapter
+from app.services.parsers.json_adapter import JsonParserAdapter
+from app.services.parsers.xml_adapter import XmlParserAdapter
+from app.services.parsers.yaml_adapter import YamlParserAdapter
+
+ADAPTERS: tuple[ParserAdapter, ...] = (
+    JsonParserAdapter(),
+    YamlParserAdapter(),
+    XmlParserAdapter(),
+)
+
+
+def resolve_parser(path: str) -> ParserAdapter:
+    suffix = PurePosixPath(path).suffix.lower()
+    for adapter in ADAPTERS:
+        if suffix in adapter.supported_extensions:
+            return adapter
+
+    raise GitHubClientError(f"Unsupported config format for {path}.", status_code=400)

--- a/apps/api/app/services/parsers/xml_adapter.py
+++ b/apps/api/app/services/parsers/xml_adapter.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from io import StringIO
+from typing import Any
+
+
+class XmlParserAdapter:
+    name = "xml"
+    supported_extensions = (".xml",)
+
+    def parse(self, content: str) -> Any:
+        element = ET.parse(StringIO(content)).getroot()
+        return {element.tag: self._element_to_object(element)}
+
+    def serialize(self, value: Any) -> str:
+        return "<!-- XML serialize stub: persistence is not wired yet -->"
+
+    def _element_to_object(self, element: ET.Element) -> Any:
+        attributes = {f"@{key}": value for key, value in element.attrib.items()}
+        child_elements = list(element)
+
+        if not child_elements:
+            text = (element.text or "").strip()
+            if attributes and text:
+                return {**attributes, "#text": text}
+            if attributes:
+                return attributes
+            return text
+
+        grouped_children: dict[str, list[Any]] = {}
+        for child in child_elements:
+            grouped_children.setdefault(child.tag, []).append(self._element_to_object(child))
+
+        normalized_children: dict[str, Any] = {}
+        for child_tag, values in grouped_children.items():
+            normalized_children[child_tag] = values[0] if len(values) == 1 else values
+
+        text = (element.text or "").strip()
+        if text:
+            normalized_children["#text"] = text
+
+        return {**attributes, **normalized_children}

--- a/apps/api/app/services/parsers/yaml_adapter.py
+++ b/apps/api/app/services/parsers/yaml_adapter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+class YamlParserAdapter:
+    name = "yaml"
+    supported_extensions = (".yaml", ".yml")
+
+    def parse(self, content: str) -> Any:
+        return yaml.safe_load(content)
+
+    def serialize(self, value: Any) -> str:
+        return yaml.safe_dump(value, sort_keys=False)

--- a/apps/web/src/components/config-editor/config-editor.tsx
+++ b/apps/web/src/components/config-editor/config-editor.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import ConfigTreeRenderer from "./config-tree-renderer";
-import { getConfigTree, type ConfigNode, type ConfigTreeResponse } from "../../lib/config-tree";
+import { getConfigTree, type ConfigTreeResponse } from "../../lib/config-tree";
+import type { ConfigNode } from "../../lib/config-node";
 
 type ToastState = {
   title: string;
@@ -30,7 +31,29 @@ export default function ConfigEditor({
   const [response, setResponse] = useState<ConfigTreeResponse | null>(null);
   const [draftTree, setDraftTree] = useState<ConfigNode | null>(null);
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<"structure" | "draft">("structure");
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [toast, setToast] = useState<ToastState | null>(null);
+
+  const isDirty =
+    response !== null && draftTree !== null && JSON.stringify(response.tree) !== JSON.stringify(draftTree);
+
+  const validationMessage =
+    draftTree && draftTree.children.length > 0
+      ? "Validation placeholder: schema rules and server validation are not wired yet."
+      : "Validation placeholder: no editable nodes were produced for the selected file.";
+
+  const resetChanges = () => {
+    if (!response) {
+      return;
+    }
+    setDraftTree(response.tree);
+    setSaveMessage(null);
+  };
+
+  const handleSaveDraft = () => {
+    setSaveMessage(`Save draft stub triggered for ${path}. Persistence will be added in a later phase.`);
+  };
 
   useEffect(() => {
     let active = true;
@@ -52,6 +75,7 @@ export default function ConfigEditor({
         console.log("config-tree", nextResponse);
         setResponse(nextResponse);
         setDraftTree(nextResponse.tree);
+        setSaveMessage(null);
       } catch (error) {
         if (!active) {
           return;
@@ -73,6 +97,20 @@ export default function ConfigEditor({
       active = false;
     };
   }, [path, repository]);
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        handleSaveDraft();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [path]);
 
   if (!repository || !path) {
     return (
@@ -118,22 +156,88 @@ export default function ConfigEditor({
             <strong>File</strong>
             <span>{path}</span>
           </div>
+          <div style={pageStyles.metaCard}>
+            <strong>Editor state</strong>
+            <span>{isDirty ? "Unsaved changes" : "All changes reset"}</span>
+          </div>
         </div>
 
         {toast ? <ErrorBanner toast={toast} /> : null}
+        {saveMessage ? (
+          <div style={pageStyles.infoBanner}>
+            <strong>Save draft</strong>
+            <span>{saveMessage}</span>
+          </div>
+        ) : null}
 
         {loading ? (
           <div style={pageStyles.emptyState}>
             <strong>Loading config structure</strong>
             <span>Fetching and normalizing the selected file.</span>
           </div>
-        ) : draftTree && draftTree.children.length > 0 ? (
-          <ConfigTreeRenderer node={draftTree} onNodeChange={setDraftTree} />
         ) : (
-          <div style={pageStyles.emptyState}>
-            <strong>No editable fields found</strong>
-            <span>The selected file parsed successfully but did not produce any editable nodes.</span>
-          </div>
+          <>
+            <div style={pageStyles.toolbar}>
+              <div style={pageStyles.tabs}>
+                {[
+                  { id: "structure", label: "Structure" },
+                  { id: "draft", label: "Draft JSON" },
+                ].map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id as "structure" | "draft")}
+                    style={{
+                      ...pageStyles.tabButton,
+                      ...(activeTab === tab.id ? pageStyles.tabButtonActive : null),
+                    }}
+                    type="button"
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              <div style={pageStyles.actions}>
+                <button
+                  disabled={!isDirty}
+                  onClick={resetChanges}
+                  style={{
+                    ...pageStyles.secondaryButton,
+                    ...(isDirty ? null : pageStyles.buttonDisabled),
+                  }}
+                  type="button"
+                >
+                  Reset changes
+                </button>
+                <button onClick={handleSaveDraft} style={pageStyles.primaryButton} type="button">
+                  Save draft
+                </button>
+              </div>
+            </div>
+
+            <section style={pageStyles.validationCard}>
+              <strong>Validation</strong>
+              <span>{validationMessage}</span>
+            </section>
+
+            {draftTree && draftTree.children.length > 0 ? (
+              activeTab === "structure" ? (
+                <ConfigTreeRenderer node={draftTree} onNodeChange={setDraftTree} />
+              ) : (
+                <section style={pageStyles.debugPanel}>
+                  <div style={pageStyles.debugHeader}>
+                    <strong>Draft payload</strong>
+                    <span>Current in-memory state after inline edits.</span>
+                  </div>
+                  <pre style={pageStyles.pre}>{JSON.stringify(draftTree, null, 2)}</pre>
+                </section>
+              )
+            ) : (
+              <div style={pageStyles.emptyState}>
+                <strong>No editable fields found</strong>
+                <span>The selected file parsed successfully but did not produce any editable nodes.</span>
+              </div>
+            )}
+          </>
         )}
 
         {response ? (
@@ -227,9 +331,75 @@ const pageStyles = {
     background: "rgba(255,255,255,0.6)",
     color: "var(--muted)",
   },
+  toolbar: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 14,
+    alignItems: "center",
+    flexWrap: "wrap" as const,
+  },
+  tabs: {
+    display: "flex",
+    gap: 10,
+    flexWrap: "wrap" as const,
+  },
+  tabButton: {
+    borderRadius: 999,
+    border: "1px solid var(--line)",
+    padding: "10px 14px",
+    background: "rgba(255,255,255,0.7)",
+    cursor: "pointer",
+  },
+  tabButtonActive: {
+    background: "var(--accent-soft)",
+    color: "var(--accent)",
+    border: "1px solid rgba(15, 118, 110, 0.22)",
+  },
+  actions: {
+    display: "flex",
+    gap: 10,
+    flexWrap: "wrap" as const,
+  },
+  primaryButton: {
+    borderRadius: 999,
+    border: 0,
+    padding: "12px 18px",
+    background: "var(--accent)",
+    color: "#f7f4ec",
+    cursor: "pointer",
+  },
+  secondaryButton: {
+    borderRadius: 999,
+    border: "1px solid var(--line)",
+    padding: "12px 18px",
+    background: "rgba(255,255,255,0.7)",
+    cursor: "pointer",
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
+  },
+  validationCard: {
+    display: "grid",
+    gap: 6,
+    padding: 16,
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid rgba(15, 118, 110, 0.16)",
+    background: "rgba(15, 118, 110, 0.07)",
+    color: "var(--muted)",
+  },
   debugPanel: {
     display: "grid",
     gap: 10,
+  },
+  infoBanner: {
+    display: "grid",
+    gap: 6,
+    padding: 16,
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid rgba(15, 118, 110, 0.16)",
+    background: "rgba(15, 118, 110, 0.1)",
+    color: "var(--accent)",
   },
   debugHeader: {
     display: "grid",

--- a/apps/web/src/components/config-editor/config-tree-renderer.tsx
+++ b/apps/web/src/components/config-editor/config-tree-renderer.tsx
@@ -2,7 +2,7 @@
 
 import ConfigSection from "./config-section";
 import KeyValueRow from "./key-value-row";
-import type { ConfigNode } from "../../lib/config-tree";
+import type { ConfigNode } from "../../lib/config-node";
 
 function inputStyle() {
   return {

--- a/apps/web/src/lib/config-node.ts
+++ b/apps/web/src/lib/config-node.ts
@@ -1,0 +1,9 @@
+export type ConfigNodeKind = "string" | "number" | "boolean" | "object" | "array" | "null";
+
+export type ConfigNode = {
+  key: string;
+  path: string;
+  kind: ConfigNodeKind;
+  value: string | number | boolean | null;
+  children: ConfigNode[];
+};

--- a/apps/web/src/lib/config-tree.ts
+++ b/apps/web/src/lib/config-tree.ts
@@ -1,12 +1,4 @@
-export type ConfigNodeKind = "string" | "number" | "boolean" | "object" | "array" | "null";
-
-export type ConfigNode = {
-  key: string;
-  path: string;
-  kind: ConfigNodeKind;
-  value: string | number | boolean | null;
-  children: ConfigNode[];
-};
+import type { ConfigNode } from "./config-node";
 
 export type ConfigTreeResponse = {
   repository: string;

--- a/docs/editor-state-diagram.md
+++ b/docs/editor-state-diagram.md
@@ -1,0 +1,17 @@
+# Editor State Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Loading
+  Loading --> Ready: config tree fetched
+  Loading --> Error: fetch fails
+  Error --> Loading: retry or reload
+
+  Ready --> Dirty: inline edit changes local state
+  Dirty --> Ready: reset changes
+  Dirty --> Saving: save draft click or Cmd/Ctrl+S
+  Saving --> Dirty: save stub returns
+
+  Ready --> Empty: no editable nodes
+  Empty --> Loading: open different file
+```

--- a/docs/parser-interface.md
+++ b/docs/parser-interface.md
@@ -1,0 +1,38 @@
+# Config Parser Interface
+
+Phase 3 standardizes the config parsing layer behind a parse/serialize contract so the editor can work against a consistent normalized tree.
+
+## Contract
+
+Each parser adapter implements:
+
+- `name`: human-readable parser id
+- `supported_extensions`: tuple of file extensions handled by the adapter
+- `parse(content: str) -> Any`: convert raw file content into a Python object graph
+- `serialize(value: Any) -> str`: convert an object graph back into a file string
+
+## Current Adapters
+
+- `JsonParserAdapter`: parses and serializes `.json`
+- `YamlParserAdapter`: parses and serializes `.yaml` / `.yml`
+- `XmlParserAdapter`: parses `.xml` and exposes a serialize stub until persistence is wired
+
+## Resolver
+
+`resolve_parser(path)` maps a file extension to the correct adapter and rejects unsupported formats before config normalization starts.
+
+## Normalized Node Shape
+
+The editor consumes a normalized tree with this shape:
+
+```ts
+type ConfigNode = {
+  key: string;
+  path: string;
+  kind: "string" | "number" | "boolean" | "object" | "array" | "null";
+  value: string | number | boolean | null;
+  children: ConfigNode[];
+};
+```
+
+This shape is language-agnostic and stable across parser implementations.


### PR DESCRIPTION
## Summary
- add parser adapter contract, JSON/YAML/XML adapters, resolver, and shared backend config node type
- document the parser interface and editor state machine
- extend the config editor with tabs, dirty-state tracking, reset changes, save draft stub, validation placeholder, and Cmd/Ctrl+S handling

## Verification
- `python3 -m compileall app`
- parser resolver check for `.json`, `.yaml`, `.yml`, `.xml`
- `npx tsc --noEmit`
- `npm run build`